### PR TITLE
fix erros

### DIFF
--- a/lib/apic.js
+++ b/lib/apic.js
@@ -68,7 +68,7 @@ define(function (require) {
 					headers = {};
 
 				if (typeof representationExpected[verb] === 'undefined') {
-					query = representation;
+					query = representation || {};
 					representation = undefined;
 				}
 


### PR DESCRIPTION
when api request looks like (in conf GET isn't representation expected method): api.things.get('things', function(){}), required params was search incorrect.
