### PR TITLE
Fixed error

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -84,6 +84,6 @@ define(function(require, exports) {
             callback(null, xhr, JSON.parse(xhr.responseText));
         };
 
-        xhr.send(options.representation);
+        xhr.send(JSON.stringify(options.data));
     };
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name"          : "apic.js",
-  "version"       : "0.4.5",
+  "version"       : "0.4.6",
   "description"   : "REST API JavaScript Client Generator",
   "keywords"      : ["js", "WADL", "api", "client", "REST"],
   "author"        : "Artem Gurtovoy <tema.gurtovoy@gmail.com>",
@@ -14,6 +14,7 @@
       "apic": "./bin/apic"
   },
   "dependencies" : {
+    "requirejs": "*",
     "commander": "*",
     "amdefine": "*"
   }


### PR DESCRIPTION
In callback onload param 'e' always no null. I think more correctly check response status.
Added setup for withCredentials xhr transport, without this param cookies no set. see https://developer.mozilla.org/en-US/docs/HTTP/Access_control_CORS#Requests_with_credentials.

Also I found and fixed some bugs, and bump minor version in last commit.
