### PR TITLE
Добавлен функционал `инвалидация кэшируемых запросов`

### DIFF
--- a/lib/apic.js
+++ b/lib/apic.js
@@ -10,6 +10,7 @@ define(function (require) {
         Exception = require('./exception');
 
     var placeholder = /^{(.+)}$/,
+        cachingTrait = '@caching',
         safeMethods = { 'GET': true, 'HEAD': true, 'OPTIONS': true },
         synonyms;
 
@@ -47,7 +48,8 @@ define(function (require) {
             variables = {},
             augments = {},
             language,
-            lastResponse;
+            lastResponse,
+            staticVersion = Math.round(Math.random()*10e9).toString(36);
 
         var scheme = 'http:';
 
@@ -92,7 +94,16 @@ define(function (require) {
             return lastResponse;
         };
 
-        function method(verb, uri, res, params, secure) {
+
+        root.getStaticVersion = function() {
+            return staticVersion;
+        };
+
+        root.setStaticVersion = function(value) {
+            staticVersion = value;
+        };
+
+        function method(verb, uri, res, params, secure, caching) {
             var safe = safeMethods[verb] || false,
                 protocol = (secure = secure || !safe) ? 'https:' : scheme;
 
@@ -163,6 +174,10 @@ define(function (require) {
 
                 if (secure && root.authorize()) {
                     headers[options.authorizationHeader] = root.authorize();
+                }
+
+                if (caching) {
+                    query['staticVersion'] = root.getStaticVersion();
                 }
 
                 if (language) {
@@ -239,6 +254,7 @@ define(function (require) {
                 value,
                 parts,
                 secure,
+                caching,
                 transparent,
                 tree,
                 _;
@@ -248,6 +264,10 @@ define(function (require) {
             for (key in map) {
                 if (map.hasOwnProperty(key) && key !== '@') {
                     value = map[key];
+
+                    /* checks caching trait */
+                    caching = key.indexOf(cachingTrait) > -1;
+                    key = key.replace(cachingTrait, '');
 
                     transparent = key.match(placeholder);
 
@@ -284,7 +304,7 @@ define(function (require) {
                         _ = key.toLowerCase();
 
                         tree = typeof value === 'string'
-                            ? method(key, uri || '/', result(value), parts, secure)
+                            ? method(key, uri || '/', result(value), parts, secure, caching)
                             : generate(value, (uri || '') + '/' + (value['@'] || key), transparent && res);
 
                         transparent || (res[_] = tree);

--- a/xsl/convert.xsl
+++ b/xsl/convert.xsl
@@ -64,7 +64,13 @@
 				</xsl:if>
 			</xsl:otherwise>
 		</xsl:choose>
-		<xsl:apply-templates select="ancestor::wadl:resource/wadl:param|wadl:request/wadl:param[@required='true']"/>
+
+        <!-- writes "@caching" trait to wadl:method -->
+        <xsl:if test="count(wadl:response/x:caching)">
+            <xsl:text>@caching</xsl:text>
+        </xsl:if>
+
+        <xsl:apply-templates select="ancestor::wadl:resource/wadl:param|wadl:request/wadl:param[@required='true']"/>
 		<xsl:text>":"</xsl:text>
 		<xsl:apply-templates select="wadl:response[substring(@status, 1, 1)='2']/wadl:representation"/>
 		<xsl:text>"</xsl:text>

--- a/xsl/convert.xsl
+++ b/xsl/convert.xsl
@@ -65,8 +65,8 @@
 			</xsl:otherwise>
 		</xsl:choose>
 
-        <!-- writes "@caching" trait to wadl:method -->
-        <xsl:if test="count(wadl:response/x:caching)">
+        <!-- writes "@caching" to `wadl:method` definition when `wadl:response/x:caching` element exist -->
+        <xsl:if test="(wadl:response/x:caching) and ((@name='GET') or (@name='HEAD'))">
             <xsl:text>@caching</xsl:text>
         </xsl:if>
 
@@ -81,7 +81,7 @@
 			<xsl:value-of select="@name"/>
 			<xsl:text>"</xsl:text>
 		</xsl:if>
-		<xsl:if test="count(following-sibling::wadl:method)or count(following-sibling::wadl:resource)">,</xsl:if>
+		<xsl:if test="count(following-sibling::wadl:method) or count(following-sibling::wadl:resource)">,</xsl:if>
 	</xsl:template>
 
 	<xsl:template match="wadl:representation">


### PR DESCRIPTION
Запросы АПИ могут кэшироваться.
Для **принудительного сброса кэша** АПИ требуется инвалидировать кэш в браузере(прокси, сдн).

В данном случае используется механизм изменения **значения query параметра `staticVersion`**.

Во время инициализации API  параметр `staticVersion` инициализируется 
случайным значением, далее параметр может быть установлен вручную внутри 
приложения-клиента:

```
require(['api'], function(api) {
    api.setStaticVersion('abcdef');
}
```

Все запросы к кэшируемым ресурсам станут:
```
GET http://host/resource?staticVersion=abcdef
```


P.S. Механизм кэширования апи доступен только для HEAD/GET запросов.
