### PR TITLE
Принудительное игнорирование первого аргумента

### DIFF
--- a/lib/apic.js
+++ b/lib/apic.js
@@ -175,7 +175,9 @@ define(function (require) {
 
                         path.indexOf(_) === -1
                             ? (path += '/' + value)
-                            : (path = path.replace(_, value));
+                            : (i == 0 && args.length > 0 && args[0] === false)
+                                ? (path = path.replace('/'+ _, ''))
+                                : (path = path.replace(_, value));
 
                         delete query[name];
                     }

--- a/lib/apic.js
+++ b/lib/apic.js
@@ -173,11 +173,13 @@ define(function (require) {
                         var _ = '{' + name + '}',
                             value = args[i] || query[name];
 
-                        path.indexOf(_) === -1
-                            ? (path += '/' + value)
-                            : (i == 0 && args.length > 0 && args[0] === false)
-                                ? (path = path.replace('/'+ _, ''))
-                                : (path = path.replace(_, value));
+                        if(path.indexOf(_) === -1){
+                            path += ('/' + value)
+                        }else if (i == 0 && args.length > 0 && args[0] === false){
+                            path = path.replace('/' + _, '');
+                        }else{
+                            path = path.replace(_, value);
+                        }
 
                         delete query[name];
                     }


### PR DESCRIPTION
Если первым аргументом будет передано значение false, то первый плейсхолдер не должен заменяться на переменную из окружения, а будет удален из URI запроса